### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # inform linguist that files with these extensions are indeed smalltalk files
 *.st linguist-language=Smalltalk
 *.gs linguist-language=Smalltalk
+*.pac linguist-language=Smalltalk


### PR DESCRIPTION
these attributes ensure that github recognizes that .st and .gs files are recognized as smalltalk files, not http files ... which is the default (yes github thinks that .st files are http files without this file) ...