### PR TITLE
declare Globals to be the default symbol dictionary for RSR packages

### DIFF
--- a/rowan/specs/RemoteServiceReplication.ston
+++ b/rowan/specs/RemoteServiceReplication.ston
@@ -10,5 +10,12 @@ RwLoadSpecificationV2 {
 	#customConditionalAttributes : [
 		'tests'
 	],
+	#platformProperties : {
+		'gemstone' : {
+			'allusers' : {
+				#defaultSymbolDictName : 'Globals'
+			}
+		}
+	},
 	#comment : 'RemoteServiceReplication development load spec'
 }


### PR DESCRIPTION
This change will not show up in your image until a rebuild is done ... I won't use daleDev for anything else until this PR is merged