### PR TITLE
Add remote exception printing to ease debugging

### DIFF
--- a/src/RemoteServiceReplication/RsrRemoteException.class.st
+++ b/src/RemoteServiceReplication/RsrRemoteException.class.st
@@ -80,6 +80,19 @@ RsrRemoteException >> messageText: aString [
 	messageText := aString
 ]
 
+{ #category : 'printing' }
+RsrRemoteException >> printOn: aStream [
+
+	aStream
+		nextPutAll: exceptionClassName;
+		cr;
+		nextPutAll: messageText;
+		cr;
+		nextPutAll: '===================';
+		cr;
+		nextPutAll: stack
+]
+
 { #category : 'accessing' }
 RsrRemoteException >> stack [
 


### PR DESCRIPTION
Given that Pharo's debugging tools are naughty (coal in their stockings this year!) and send messages to proxies, having a method to easily print the useful information in a remote exception is helpful.