### PR TITLE
make RSR dependent upon new GemTalk/Announcements project

### DIFF
--- a/rowan/components/RemoteServiceReplication.ston
+++ b/rowan/components/RemoteServiceReplication.ston
@@ -1,7 +1,9 @@
 RwSimpleProjectLoadComponentV2 {
 	#name : 'RemoteServiceReplication',
 	#condition : 'common',
-	#projectNames : [ ],
+	#projectNames : [
+		'Announcements'
+	],
 	#componentNames : [
 		'gemstone/RemoteServiceReplication',
 		'tests/RemoteServiceReplication'

--- a/rowan/components/gemstone/RemoteServiceReplication.ston
+++ b/rowan/components/gemstone/RemoteServiceReplication.ston
@@ -1,6 +1,8 @@
-RwSimpleProjectLoadComponentV2 {
+RwPlatformNestedProjectLoadComponentV2 {
 	#name : 'gemstone/RemoteServiceReplication',
-	#condition : 'gemstone',
+	#condition : [
+		'gs3.[7-]'
+	],
 	#projectNames : [ ],
 	#componentNames : [ ],
 	#packageNames : [

--- a/rowan/projects/Announcements.ston
+++ b/rowan/projects/Announcements.ston
@@ -1,0 +1,22 @@
+RwLoadSpecificationV2 {
+	#specName : 'Announcements',
+	#projectName : 'Announcements',
+	#gitUrl : 'git@github.com:GemTalk/Announcements.git',
+	#revision : 'development',
+	#projectSpecFile : 'rowan/project.ston',
+	#componentNames : [
+		'Announcements'
+	],
+	#customConditionalAttributes : [
+		'deprecated',
+		'tests'
+	],
+	#platformProperties : {
+		'gemstone' : {
+			'allusers' : {
+				#defaultSymbolDictName : 'Globals'
+			}
+		}
+	},
+	#comment : 'Announcements development load spec'
+}

--- a/rowan/projects/Announcements.ston
+++ b/rowan/projects/Announcements.ston
@@ -2,7 +2,7 @@ RwLoadSpecificationV2 {
 	#specName : 'Announcements',
 	#projectName : 'Announcements',
 	#gitUrl : 'git@github.com:GemTalk/Announcements.git',
-	#revision : 'development',
+	#revision : 'main',
 	#projectSpecFile : 'rowan/project.ston',
 	#componentNames : [
 		'Announcements'


### PR DESCRIPTION
As described in GemTalk/Sparkle#51, added Announcements as required project and change the gemstone conditional to be more specific (open ended range of GemStone versions starting with 3.7.0).

Should coordinate with PR GemTalk/Sparkle#55, since RSR probably needs to be merged first as it is independent of Sparkle, but Sparkle is dependent up RSR for this change ..

Should be using the latest Rowan masterV2.1 branch for best results.

Also note that new Announcements project will be automatically cloned to $ROWAN_PROJECTS_HOME on first load.

Note that Sparkle's bootstrap .gs files now include RSR (and Announcements) so it may not be critical to maintain .gs files for RSR. @kurtkilpela, if you want to include Announcements in your bootstrap .gs files (and optionally separate tests bootstrap .gs file ala Sparkle) create an issue and assign it to me and I will make it so ...